### PR TITLE
Recaptcha support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,10 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+Staticman's reCAPTCHA support
+=================================================================================
+
+The MIT License (MIT)
+
+Original work Copyright (c) 2019 Praveen Lobo and Munif Tanjim

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ By default, [Staticman](https://staticman.net) comments are disabled. If you wou
           Go to **Settings → Repository → Protected Branches** and permit the GitLab bot to push against that branch.
       - unprotected branch (GitHub's default): no measures needed
 
+Optional: It is suggested to enable [reCAPTCHA](https://developers.google.com/recaptcha/docs/display) to avoid massive spam comments. You may refer to `_config.yml` for detailed instructions.
+
 :information_source: This [Binary Mist article](https://binarymist.io/blog/2018/02/24/hugo-with-staticman-commenting-and-subscriptions/) could also be quite helpful :)
 
 :information_source: By default, this theme uses Staticman v3 instead of the public instance at v2 due to a requests' quota issue reported in issue [eduardoboucas/staticman#222](https://github.com/eduardoboucas/staticman/issues/222).

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -11,9 +11,14 @@ pygmentsCodefences = true
 pygmentsCodefencesGuessSyntax = true
 pygmentsStyle = "friendly"
 
-# [Params.staticman]
-#   endpoint = "https://api.staticman.net"  # URL of your own API deployment (without trailing slash), default: "https://api.staticman.net"
-#   gitProvider = "github"  # Either "github" or "gitlab"
-#   username = "username"  # GitHub/GitLab user name
-#   repository = "repo"  # GitHub/GitLab user name
-#   branch = "master"  # Branch holding the source code for your site, should match the `branch` parameter in `staticman.yml`
+#[Params.staticman]
+#  endpoint = "https://api.staticman.net"  # URL of your own API deployment (without trailing slash), default: "https://api.staticman.net"
+#  gitProvider = "github"  # Either "github" or "gitlab"
+#  username = "username"  # GitHub/GitLab user name
+#  repository = "repo"  # GitHub/GitLab user name
+#  branch = "master"  # Branch holding the source code for your site, should match the `branch` parameter in `staticman.yml`
+ 
+## If you use reCAPTCHA v2, you must also set these parameters in staticman.yml
+#  [Params.staticman.reCaptcha]
+#    siteKey = ""  # Use your own site key, you need to apply for one on Google
+#    secret  = ""  # ENCRYPT your password by going to https://<staticman-endpoint>/v3/encrypt/<your-site-secret>

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -11,14 +11,14 @@ pygmentsCodefences = true
 pygmentsCodefencesGuessSyntax = true
 pygmentsStyle = "friendly"
 
-#[Params.staticman]
-#  endpoint = "https://api.staticman.net"  # URL of your own API deployment (without trailing slash), default: "https://api.staticman.net"
-#  gitProvider = "github"  # Either "github" or "gitlab"
-#  username = "username"  # GitHub/GitLab user name
-#  repository = "repo"  # GitHub/GitLab user name
-#  branch = "master"  # Branch holding the source code for your site, should match the `branch` parameter in `staticman.yml`
- 
-## If you use reCAPTCHA v2, you must also set these parameters in staticman.yml
-#  [Params.staticman.reCaptcha]
-#    siteKey = ""  # Use your own site key, you need to apply for one on Google
-#    secret  = ""  # ENCRYPT your password by going to https://<staticman-endpoint>/v3/encrypt/<your-site-secret>
+# [Params.staticman]
+#   endpoint = "https://api.staticman.net"  # URL of your own API deployment (without trailing slash), default: "https://api.staticman.net"
+#   gitProvider = "github"  # Either "github" or "gitlab"
+#   username = "username"  # GitHub/GitLab user name
+#   repository = "repo"  # GitHub/GitLab user name
+#   branch = "master"  # Branch holding the source code for your site, should match the `branch` parameter in `staticman.yml`
+#
+#   # If you use reCAPTCHA v2, you must also set these parameters in staticman.yml
+#   [Params.staticman.reCaptcha]
+#     siteKey = ""  # Use your own site key, you need to apply for one on Google
+#     secret  = ""  # ENCRYPT your password by going to https://<staticman-endpoint>/v3/encrypt/<your-site-secret>

--- a/exampleSite/staticman.yml
+++ b/exampleSite/staticman.yml
@@ -17,3 +17,15 @@ comments:
   requiredFields: ["name", "email", "comment"]
   transforms:
     email: md5
+
+  # reCAPTCHA (OPTIONAL)
+  # Register your domain at https://www.google.com/recaptcha/ and choose reCAPTCHA V2
+  # Use your OWN siteKey and secret.
+  reCaptcha:
+    enabled: false
+    # siteKey and secret should match your config.toml
+    #siteKey: "6Lcv8G8UAAAAAEqV1Y-XEPum00C_DxhD6O--qkFo"
+    # (!) ENCRYPT reCaptcha secret key using Staticman /encrypt endpoint
+    # i.e. https://{staticman-endpoint}/v3/encrypt/{your-site-secret}
+    # For more information, https://staticman.net/docs/encryption
+    #secret: "p5uHlH9hCqpMJaGKXdt5MEWFo7K6fX8hoYUwR3aIafOI6rtItLauaDCkGOucysJtrVZy+sHffioGzMsOU64JFDSyPQgrXujegcOHFRXHhD4fOUuBXSvV+OZ8JhSPTGWaRcQcoiGX4pT5hlebLddOl59b6sn6kU1ODQcEbhP83xVLZlaTWOrNrF5Wvy3TMXpH5gyl1tZEORxADAShMYyUbNR7XZYLEg1DfgIBHfIg3cKwdFt7KVLejFGKIiBYRAZDE2JuHItNmzJ2x9JgSK3E+XnShV5tuWpncnyFonJVHGEky/zRfUVLHobDMcJ/u9nlZqE8u47W+833F1WaIYuwNw=="

--- a/layouts/partials/comments-form.html
+++ b/layouts/partials/comments-form.html
@@ -12,7 +12,6 @@
   <input name = 'fields[email]' type = 'email' placeholder = 'Email' class = 'form_input' required>
   <label class = 'form_label'>Comment</label>
   <textarea name = 'fields[comment]' placeholder = 'Type in a comment ...' class = 'form_input form_input-message' required></textarea>
-  <input type = 'submit' value = 'Comment' class = 'form_input form_input-submit' {{- if $vs.reCaptcha }} disabled {{- end }}>
 
   {{- if $vs.reCaptcha -}}
     <div class = 'g-recaptcha' data-sitekey = '{{ $vs.reCaptcha.siteKey }}' data-callback='enableSubmitComment'></div>
@@ -25,4 +24,6 @@
 
     <script async src = 'https://www.google.com/recaptcha/api.js'></script>
   {{- end -}}
+
+  <input type = 'submit' id = 'submitComment' value = 'Comment' class = 'form_input form_input-submit' {{- if $vs.reCaptcha }} disabled {{- end }}>
 </form>

--- a/layouts/partials/comments-form.html
+++ b/layouts/partials/comments-form.html
@@ -2,11 +2,27 @@
 <span class = 'form_toggle'>Comment</span>
 <form method = 'POST' action = '{{ $vs.endpoint | default "https://api.staticman.net" }}/v3/entry/{{ $vs.gitProvider }}/{{ $vs.username }}/{{ $vs.repository }}/{{ $vs.branch }}/comments' class  = 'form form-comments' id = 'comments-form'>
   <input name = 'options[slug]' type = 'hidden' value = '{{ .File.UniqueID }}'>
+  {{- if $vs.reCaptcha -}}
+    <input name = 'options[reCaptcha][siteKey]' type = 'hidden' value = '{{ $vs.reCaptcha.siteKey }}'>
+    <input name = 'options[reCaptcha][secret]' type = 'hidden' value = '{{ $vs.reCaptcha.secret }}'>
+  {{- end -}}
   <label class = 'form_label'>Name</label>
   <input name = 'fields[name]' type = 'text' placeholder = 'Name' class = 'form_input' required>
   <label class = 'form_label'>E-mail</label>
   <input name = 'fields[email]' type = 'email' placeholder = 'Email' class = 'form_input' required>
   <label class = 'form_label'>Comment</label>
   <textarea name = 'fields[comment]' placeholder = 'Type in a comment ...' class = 'form_input form_input-message' required></textarea>
-  <input type = 'submit' value = 'Comment' class = 'form_input form_input-submit'>
+  <input type = 'submit' value = 'Comment' class = 'form_input form_input-submit' {{- if $vs.reCaptcha }} disabled {{- end }}>
+
+  {{- if $vs.reCaptcha -}}
+    <div class = 'g-recaptcha' data-sitekey = '{{ $vs.reCaptcha.siteKey }}' data-callback='enableSubmitComment'></div>
+
+    <script type="text/javascript">
+      function enableSubmitComment(){
+        document.getElementById('submitComment').disabled = false;
+      }
+    </script>
+
+    <script async src = 'https://www.google.com/recaptcha/api.js'></script>
+  {{- end -}}
 </form>


### PR DESCRIPTION
A port of MunifTanjim/minimo#224.  TODO

- [x] Go-HTML template file
- [x] doucmentation update
    1. README: users would see the recommendation to use reCATPCHA, and are referred to site config 
    2. `config.toml`: users would see the commented guide for reCATPCHA setup, and are referred to Staticman repo config
    3. `staticman.yml` (root-level): at the first glance, everyone knows that this theme would support reCAPTCHA v2.
        + reCAPTCHA users: change `enabled` to `true`, and the commented lines show them what to do.  It'd be clear that they have to **use `/v3/encrypt`**, contrary to [Staticman's documentation](https://staticman.net/docs/encryption).
        + non users: just keep this section untouched.  reCAPTCHA would be disabled.
    4. LICENSE: give credits to the original authors of the code
    5. Go-HTML template file: mostly copied from the linked PR, with some necessary adaptions to this theme's template code.  Note that I _didn't_ implement the "input reCAPTCHA parameters only once" here.  My reason is to avoid loading the entire `staticman.yml` for each site regeneration for just two reCAPTCHA parameters, which are usually loaded from the site config file.  The linked PR uses Hugo cache, which quite complicated.
- [x] test feature at my demo site: https://staticman-gitlab-pages.frama.io/hugo-swift-theme
- [ ] CSS issues: I'll leave this since I'm not quite familiar with CSS
    - vertical separation around the reCAPTCHA box
    - opacity of the submit button when `disabled`