### PR TITLE
WIP: Improved internal links construction and Staticman nested comments

### DIFF
--- a/assets/_fonts.scss
+++ b/assets/_fonts.scss
@@ -1,46 +1,46 @@
 @font-face {
   font-family: 'Metropolis';
   font-style: normal;
-  font-weight: 400; 
+  font-weight: 400;
   src: local('Metropolis Regular'), local('Metropolis-Regular'),
-       url('/fonts/Metropolis-Regular.woff2') format('woff2'), // Super Modern Browsers 
-       url('/fonts/Metropolis-Regular.woff') format('woff'), // Modern Browsers 
+       url('#{$font-path}/Metropolis-Regular.woff2') format('woff2'), // Super Modern Browsers
+       url('#{$font-path}/Metropolis-Regular.woff') format('woff'), // Modern Browsers
 }
 
 @font-face {
   font-family: 'Metropolis';
   font-style: normal;
-  font-weight: 300; 
+  font-weight: 300;
   src: local('Metropolis Light'), local('Metropolis-Light'),
-       url('/fonts/Metropolis-Light.woff2') format('woff2'), // Super Modern Browsers 
-       url('/fonts/Metropolis-Light.woff') format('woff'), // Modern Browsers 
+       url('#{$font-path}/Metropolis-Light.woff2') format('woff2'), // Super Modern Browsers
+       url('#{$font-path}/Metropolis-Light.woff') format('woff'), // Modern Browsers
 }
 
 @font-face {
   font-family: 'Metropolis';
   font-style: italic;
-  font-weight: 300; 
+  font-weight: 300;
   src: local('Metropolis Light Italic'), local('Metropolis-LightItalic'),
-       url('/fonts/Metropolis-LightItalic.woff2') format('woff2'), // Super Modern Browsers 
-       url('/fonts/Metropolis-LightItalic.woff') format('woff'), // Modern Browsers 
+       url('#{$font-path}/Metropolis-LightItalic.woff2') format('woff2'), // Super Modern Browsers
+       url('#{$font-path}/Metropolis-LightItalic.woff') format('woff'), // Modern Browsers
 }
 
 @font-face {
   font-family: 'Metropolis';
   font-style: normal;
-  font-weight: 500; 
+  font-weight: 500;
   src: local('Metropolis Medium'), local('Metropolis-Medium'),
-       url('/fonts/Metropolis-Medium.woff2') format('woff2'), // Super Modern Browsers 
-       url('/fonts/Metropolis-Medium.woff') format('woff'), // Modern Browsers 
+       url('#{$font-path}/Metropolis-Medium.woff2') format('woff2'), // Super Modern Browsers
+       url('#{$font-path}/Metropolis-Medium.woff') format('woff'), // Modern Browsers
 }
 
 @font-face {
   font-family: 'Metropolis';
   font-style: italic;
-  font-weight: 500; 
+  font-weight: 500;
   src: local('Metropolis Medium Italic'), local('Metropolis-MediumItalic'),
-       url('/fonts/Metropolis-MediumItalic.woff2') format('woff2'), // Super Modern Browsers 
-       url('/fonts/Metropolis-MediumItalic.woff') format('woff'), // Modern Browsers 
+       url('#{$font-path}/Metropolis-MediumItalic.woff2') format('woff2'), // Super Modern Browsers
+       url('#{$font-path}/Metropolis-MediumItalic.woff') format('woff'), // Modern Browsers
 }
 
 @font-face {
@@ -48,6 +48,6 @@
   font-style: normal;
   font-weight: 400;
   src: local('Cookie-Regular'),
-       url('/fonts/cookie-v10-latin-regular.woff2') format('woff2'), // Super Modern Browsers
-       url('/fonts/cookie-v10-latin-regular.woff') format('woff'), // Modern Browsers
+       url('#{$font-path}/cookie-v10-latin-regular.woff2') format('woff2'), // Super Modern Browsers
+       url('#{$font-path}/cookie-v10-latin-regular.woff') format('woff'), // Modern Browsers
 }

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,14 +1,16 @@
+$font-path: '{{ "fonts" | relURL }}';
+
 @import
 'fonts',
-'variables', 
-'mixins', 
-'animate', 
-'base', 
-'components', 
-'utils', 
+'variables',
+'mixins',
+'animate',
+'base',
+'components',
+'utils',
 'nav',
 'posts',
 'audio',
-'footer', 
+'footer',
 'comments',
 'syntax';

--- a/exampleSite/resources/_gen/assets/scss/main.scss_c79ad86cebd6227dfe3ea421338d2ba7.json
+++ b/exampleSite/resources/_gen/assets/scss/main.scss_c79ad86cebd6227dfe3ea421338d2ba7.json
@@ -1,1 +1,0 @@
-{"Target":"main.css","MediaType":"text/css","Data":{}}

--- a/exampleSite/resources/_gen/assets/scss/main.scss_cabce47595c8b45ffa81339308153107.content
+++ b/exampleSite/resources/_gen/assets/scss/main.scss_cabce47595c8b45ffa81339308153107.content
@@ -3,42 +3,61 @@
   font-family: 'Metropolis';
   font-style: normal;
   font-weight: 400;
-  src: local("Metropolis Regular"), local("Metropolis-Regular"), url("fonts/Metropolis-Regular.woff2") format("woff2"), url("fonts/Metropolis-Regular.woff") format("woff");
+  src: local("Metropolis Regular"), local("Metropolis-Regular"), url("/fonts/Metropolis-Regular.woff2") format("woff2"), url("/fonts/Metropolis-Regular.woff") format("woff");
 }
 
 @font-face {
   font-family: 'Metropolis';
   font-style: normal;
   font-weight: 300;
-  src: local("Metropolis Light"), local("Metropolis-Light"), url("fonts/Metropolis-Light.woff2") format("woff2"), url("fonts/Metropolis-Light.woff") format("woff");
+  src: local("Metropolis Light"), local("Metropolis-Light"), url("/fonts/Metropolis-Light.woff2") format("woff2"), url("/fonts/Metropolis-Light.woff") format("woff");
 }
 
 @font-face {
   font-family: 'Metropolis';
   font-style: italic;
   font-weight: 300;
-  src: local("Metropolis Light Italic"), local("Metropolis-LightItalic"), url("fonts/Metropolis-LightItalic.woff2") format("woff2"), url("fonts/Metropolis-LightItalic.woff") format("woff");
+  src: local("Metropolis Light Italic"), local("Metropolis-LightItalic"), url("/fonts/Metropolis-LightItalic.woff2") format("woff2"), url("/fonts/Metropolis-LightItalic.woff") format("woff");
 }
 
 @font-face {
   font-family: 'Metropolis';
   font-style: normal;
   font-weight: 500;
-  src: local("Metropolis Medium"), local("Metropolis-Medium"), url("fonts/Metropolis-Medium.woff2") format("woff2"), url("fonts/Metropolis-Medium.woff") format("woff");
+  src: local("Metropolis Medium"), local("Metropolis-Medium"), url("/fonts/Metropolis-Medium.woff2") format("woff2"), url("/fonts/Metropolis-Medium.woff") format("woff");
 }
 
 @font-face {
   font-family: 'Metropolis';
   font-style: italic;
   font-weight: 500;
-  src: local("Metropolis Medium Italic"), local("Metropolis-MediumItalic"), url("fonts/Metropolis-MediumItalic.woff2") format("woff2"), url("fonts/Metropolis-MediumItalic.woff") format("woff");
+  src: local("Metropolis Medium Italic"), local("Metropolis-MediumItalic"), url("/fonts/Metropolis-MediumItalic.woff2") format("woff2"), url("/fonts/Metropolis-MediumItalic.woff") format("woff");
 }
 
 @font-face {
   font-family: 'Cookie';
   font-style: normal;
   font-weight: 400;
-  src: local("Cookie-Regular"), url("fonts/cookie-v10-latin-regular.woff2") format("woff2"), url("fonts/cookie-v10-latin-regular.woff") format("woff");
+  src: local("Cookie-Regular"), url("/fonts/cookie-v10-latin-regular.woff2") format("woff2"), url("/fonts/cookie-v10-latin-regular.woff") format("woff");
+}
+
+:root {
+  --light: #fff;
+  --dark: #131313;
+  --gray: #f5f5f5;
+  --bubble: #181818;
+  --accent: var(--gray);
+  --bg: var(--light);
+  --text: var(--dark);
+  --font: 'Metropolis', sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: var(--dark);
+    --text: var(--light);
+    --accent: var(--bubble);
+  }
 }
 
 .view {
@@ -102,9 +121,14 @@
   padding: 0;
 }
 
+body, html {
+  scroll-behavior: smooth;
+}
+
 body {
-  font-family: "Metropolis", sans-serif;
-  color: #343434;
+  font-family: var(--font);
+  background-color: var(--bg);
+  color: var(--text);
   font-size: 16px;
   line-height: 1.5;
   max-width: 1440px;
@@ -115,6 +139,8 @@ body {
   flex-direction: column;
   justify-content: space-between;
   min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 a {
@@ -123,17 +149,27 @@ a {
 }
 
 blockquote {
-  color: #768594;
-  padding: 1rem 1rem 1rem 0;
+  opacity: 0.8;
+  padding: 1rem;
   position: relative;
   quotes: "“" "”" "‘" "’";
-  margin: 0;
+  margin: 0.75rem 0;
   display: flex;
   flex-flow: row wrap;
-  background-image: url(/images/quotes.svg);
   background-repeat: no-repeat;
   background-size: 5rem;
   background-position: 50% 50%;
+  position: relative;
+}
+
+blockquote::before {
+  content: "";
+  padding: 1px;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  background: #04a763;
 }
 
 blockquote p {
@@ -151,13 +187,13 @@ code {
 }
 
 h1, h2, h3, h4, h5 {
-  font-family: "Metropolis", sans-serif;
+  font-family: inherit;
   text-transform: capitalize;
   text-align: center;
   font-weight: 500;
   padding: 5px 0;
   margin: 15px 0;
-  color: #000;
+  color: inherit;
 }
 
 h1 {
@@ -205,50 +241,58 @@ ul {
 
 b, strong, em {
   font-weight: 500;
-  color: #000;
+}
+
+hr {
+  border: none;
+  padding: 0.5px;
+  background: var(--text);
+  opacity: 0.5;
+  margin: 1rem 0;
 }
 
 .intro {
-  margin: 75px 0 15px;
-  background: #24292e;
-  padding: 30px 25px;
+  margin: 4rem 0 1rem;
+  background: #131313;
+  padding: 2rem 1.5rem;
+  color: #fff;
 }
 
 .intro_inner {
-  max-width: 840px;
+  max-width: 59rem;
   margin: 25px auto;
   margin: 0 auto;
   text-align: center;
   padding: 25px;
   position: relative;
-  box-shadow: 0 0 130px rgba(0, 0, 0, 0.17);
-  border-radius: 10px;
+  background-color: var(--bubble);
+  border-radius: 1rem;
 }
 
 .intro_headline {
   margin: 0 auto;
-  color: #fff;
   font-weight: 300;
 }
 
 .intro_desc {
-  color: #cccccc;
+  opacity: 0.8;
   text-align: center;
 }
 
 .show {
   display: block;
   position: relative;
-  background-color: #24292e;
-  border-radius: 6px;
+  background-color: #131313;
+  border-radius: 0.5rem 0.5rem 0 0;
   background-size: cover;
   background-position: center;
   overflow: hidden;
-  height: 150px;
+  height: 10rem;
 }
 
 .show::after {
   content: '';
+  position: absolute;
   left: 0;
   right: 0;
   bottom: 0;
@@ -257,15 +301,21 @@ b, strong, em {
 }
 
 .show:hover::after {
-  background-color: rgba(0, 0, 0, 0.3);
+  background-color: rgba(19, 19, 19, 0.3);
 }
 
-.excerpt {
-  padding: 20px 10px;
-  position: relative;
-  margin-top: -30px;
-  z-index: 1;
-  background: #fff;
+.btn {
+  min-width: 150px;
+  font-size: 1rem;
+  margin: 1rem 0 1.5rem;
+  display: inline-block;
+  padding: 7.5px 12.5px;
+  background-color: #04a763;
+  box-shadow: 0 1rem 4rem rgba(19, 19, 19, 0.5);
+  color: #fff;
+  text-align: center;
+  cursor: pointer;
+  border-radius: 0.25rem;
 }
 
 .gravatar {
@@ -276,20 +326,12 @@ b, strong, em {
   position: absolute;
   bottom: -30px;
   margin: 0 10px 0 0;
-  box-shadow: 0 10px 25px -2px rgba(158, 174, 221, 0.2);
-  -webkit-filter: drop-shadow(-25px 15px 15px rgba(52, 90, 64, 0.17));
-  filter: drop-shadow(-25px 15px 15px rgba(52, 90, 64, 0.17));
+  box-shadow: 0 0 3rem rgba(0, 0, 0, 0.17);
   z-index: 2;
 }
 
-.pretty {
-  min-width: 150px;
-  font-size: 1.33rem;
-  margin: 15px 0;
-  display: inline-block;
-  padding: 7.5px 12.5px;
-  background-color: #24292e;
-  color: #fff;
+.gravatar:hover {
+  box-shadow: 0 0 5rem rgba(0, 0, 0, 0.255);
 }
 
 aside h3 {
@@ -297,35 +339,9 @@ aside h3 {
   margin: 0 !important;
 }
 
-.widget {
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  width: 100%;
-  background-color: rgba(0, 0, 0, 0.6);
-  padding: 25px;
-}
-
 .nav-secondary,
 .user-menu {
   display: none !important;
-}
-
-.facebook,
-.twitter,
-.whatsapp {
-  width: 100%;
-  height: 24px;
-  font-size: 20px;
-  display: inline-block;
-}
-
-.facebook {
-  color: #3b5998;
-}
-
-.twitter {
-  color: #1da1f2;
 }
 
 span.right {
@@ -350,59 +366,6 @@ section p {
   padding: 30px 40px 50px 40px;
 }
 
-.project {
-  padding: 40px 15px;
-  text-align: left;
-  border-radius: 10px;
-  box-shadow: 0 10px 25px -2px rgba(158, 174, 221, 0.2);
-}
-
-.projects {
-  justify-content: space-between;
-  max-width: 1024px;
-  margin: 25px auto;
-  font-size: 1.25rem;
-  padding: 25px;
-}
-
-.project__thumb {
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  width: 50px;
-  height: 50px;
-  border-radius: 50%;
-  color: #fff;
-  margin-right: 25px;
-}
-
-.projects .trio h3 {
-  color: white;
-  z-index: 1;
-}
-
-.third {
-  width: 100%;
-}
-
-.poetic {
-  display: block;
-  margin: 0 auto;
-  width: 270px;
-  color: #eee;
-  font-size: 1.05em;
-  font-style: italic;
-  font-weight: 300;
-}
-
-.button {
-  background-color: #f5f5f5;
-  width: 250px;
-  padding: 15px;
-  display: block;
-  margin: auto;
-}
-
 .hold {
   position: relative;
   overflow: visible;
@@ -411,26 +374,6 @@ section p {
 .site__icon {
   width: 40px;
   margin: 0 10px 0 0;
-}
-
-#author {
-  width: 240px;
-  margin: 0 auto;
-  border-radius: 50%;
-  cursor: pointer;
-}
-
-#author img {
-  display: block;
-  margin: 10px auto;
-  border-radius: 50%;
-  width: 125px;
-}
-
-@media screen and (min-width: 567px) {
-  .third {
-    width: 49%;
-  }
 }
 
 @media screen and (min-width: 769px) {
@@ -442,20 +385,113 @@ section p {
   .duo {
     width: 46.5%;
   }
-  .third {
-    width: 49%;
-  }
   .mobile {
     display: none;
   }
 }
 
-.mute {
-  color: #cccccc;
+.video {
+  overflow: hidden;
+  padding-bottom: 56.25%;
+  position: relative;
+  height: 0;
+  margin: 1.5rem 0;
+  border-radius: 1rem;
+  background-color: var(--bg);
+  box-shadow: 0 1rem 4rem rgba(19, 19, 19, 0.17);
+}
+
+.video iframe {
+  left: 0;
+  top: 0;
+  height: 100%;
+  width: 100%;
+  position: absolute;
+  transform: scale(1.03);
+}
+
+.copy {
+  position: relative;
+  width: 1.5rem;
+  height: 1.5rem;
+  background-image: url(/images/icons/copy.svg);
+  background-size: 100%;
+  cursor: pointer;
+}
+
+.copy::before, .copy::after {
+  content: "";
+  position: absolute;
+  background: #04a763;
+  color: #fff;
+  opacity: 0;
+  transition: opacity 0.25s ease-in;
+}
+
+.copy::before {
+  content: "Share Story";
+  font-size: 0.8rem;
+  width: 5.4rem;
+  padding: 0.25rem;
+  border-radius: 0.25rem;
+  text-align: center;
+  top: -2rem;
+  right: 0;
+}
+
+.copy:hover::before, .copy:hover::after {
+  opacity: 1;
+}
+
+.author,
+.comment {
+  display: grid;
+  grid-template-columns: 4rem 1fr;
+  grid-gap: 0 1rem;
+  padding: 1rem;
+  margin: 1.5rem 0;
+  background-color: var(--accent);
+  border-radius: 0.5rem;
+  box-shadow: 0 0.5rem 2rem rgba(19, 19, 19, 0.12);
+}
+
+.author_name,
+.comment_name {
+  color: var(--text) !important;
+  font-size: 1.25rem;
+  text-transform: capitalize;
+}
+
+.author_pic,
+.comment_pic {
+  border-radius: 50%;
+  padding: 0.25rem;
+  margin: 0 0 0 -0.25rem;
+  border-color: #04a763 transparent;
+  border-style: solid;
+  border-width: 1px;
+}
+
+.author_bio,
+.comment_bio {
+  padding-bottom: 0 !important;
+  line-height: 1.33;
+}
+
+.author_heading,
+.comment_heading {
+  font-size: 0.7rem;
+}
+
+.author_meta,
+.comment_meta {
+  display: flex;
+  flex-flow: column;
+  justify-content: center;
 }
 
 .pale {
-  color: #515c67;
+  opacity: 0.7;
 }
 
 .hidden {
@@ -497,6 +533,23 @@ section p {
   margin-top: 30px;
 }
 
+.link {
+  display: inline-block;
+  width: 2.5rem;
+  margin: 0 0.25rem;
+  padding: 0 0.25rem;
+  opacity: 0;
+  transition: opacity 0.3s cubic-bezier(0.39, 0.575, 0.565, 1);
+}
+
+.link_owner:hover .link {
+  opacity: 0.9;
+}
+
+.solo {
+  grid-column: 1/-1;
+}
+
 .nav {
   position: absolute;
   top: 0;
@@ -505,22 +558,44 @@ section p {
   z-index: 999;
 }
 
-.nav-bar {
+.nav_bar {
+  width: 100%;
+  position: relative;
+}
+
+.nav_bar-wrap {
+  width: 1.8rem;
+  height: 1.8rem;
+  display: grid;
+  align-items: center;
   cursor: pointer;
+  z-index: 99;
+  min-height: 1.5rem;
+}
+
+.nav_bar, .nav_bar::after, .nav_bar::before {
+  padding: 1px;
+  border-radius: 2px;
+  background-color: var(--text);
+}
+
+.nav_bar::after, .nav_bar::before {
+  content: "";
   position: absolute;
-  top: 0;
-  right: 25px;
-  padding: 12.5px;
-  width: 40px;
-  height: auto;
-  z-index: 2;
-  font-size: 1.5em;
+  width: 1.2rem;
+}
+
+.nav_bar::before {
+  top: -0.5rem;
+}
+
+.nav_bar::after {
+  top: 0.5rem;
+  right: 0;
 }
 
 .nav-body {
-  box-shadow: 0 10px 25px -2px rgba(158, 174, 221, 0.2);
-  -webkit-filter: drop-shadow(-25px 15px 15px rgba(52, 90, 64, 0.17));
-  filter: drop-shadow(-25px 15px 15px rgba(52, 90, 64, 0.17));
+  box-shadow: 0 0 3rem rgba(0, 0, 0, 0.17);
   position: fixed;
   right: 10px;
   z-index: 1;
@@ -529,21 +604,25 @@ section p {
   overflow: hidden;
   transition: top 0.33s linear;
   background: transparent;
-  background-color: #fff;
+  background-color: var(--accent);
   width: 33.3%;
-  min-width: 240px;
-  max-width: 320px;
+  width: 16rem;
   padding: 100px 0;
-  height: 100vh;
+  min-height: 67vh;
+  margin-top: 0.5rem;
   z-index: 1;
+  border-radius: 0.33rem;
+}
+
+.nav-body:hover {
+  box-shadow: 0 0 5rem rgba(0, 0, 0, 0.255);
 }
 
 .nav-body a {
   display: block;
   padding: 12.5px 25px;
   margin-bottom: 2px;
-  border-bottom: 1px solid #f5f5f5;
-  color: #24292e;
+  border-bottom: 1px solid rgba(19, 19, 19, 0.04);
   transition: color 0.25s ease-in-out;
 }
 
@@ -556,6 +635,7 @@ section p {
   font-size: 2em !important;
   max-width: 250px;
   padding-top: 0 !important;
+  padding-bottom: 0 !important;
 }
 
 .nav-close {
@@ -563,7 +643,7 @@ section p {
   justify-content: flex-start;
   align-items: center;
   position: absolute;
-  top: 10px;
+  top: 0;
   right: 0;
   width: 100%;
   cursor: pointer;
@@ -575,7 +655,8 @@ section p {
   width: 18px;
   border-radius: 50%;
   padding: 1.5px;
-  background: #666;
+  background: var(--text);
+  opacity: 0.7;
   position: relative;
 }
 
@@ -604,6 +685,9 @@ section p {
   height: 100%;
   max-width: 1024px;
   margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .nav-menu a {
@@ -623,64 +707,16 @@ section p {
   animation: showMenu 0.5s ease-out forwards;
 }
 
-.darken,
-.darken .overlay {
-  background: transparent;
-  color: #24292e;
-}
-
-.chimp {
-  position: relative;
-  width: 90%;
-  max-width: 375px;
-  margin: 30px auto;
-}
-
-.chimp_input {
-  width: 100%;
-  height: 54px;
-  padding: 5px 20px;
-  font-size: 1.15rem;
-  border-radius: 30px;
-  border: 1px solid #04a763;
-  outline: none;
-  transition: all 0.3s ease-out;
-}
-
-.chimp_input:focus {
-  box-shadow: 0 15px 40px 0 rgba(158, 174, 221, 0.2);
-}
-
-.chimp_submit {
-  position: absolute;
-  top: 5px;
-  right: 5px;
-  background: linear-gradient(to right bottom, #037545, #04a763);
-  display: inline-block;
-  height: 44px;
-  padding: 5px 20px;
-  color: #fff;
-  border: 0;
-  outline: 0;
-  cursor: pointer;
-  border-radius: 25px;
-  font-size: 1.1rem;
-  transition: background 0.25s, color 0.2s;
-}
-
-.chimp_submit:hover {
-  background: #fff;
-  color: #24292e;
-  border: 1px solid rgba(83, 83, 83, 0.2);
-  box-shadow: 0 2px 14px 0 rgba(83, 83, 83, 0.2);
+.nav_item {
+  text-transform: capitalize;
 }
 
 .post {
   margin: 0 auto;
-  padding: 15px 25px;
+  padding: 1rem 1.5rem;
   width: 100%;
   max-width: 750px;
-  margin-top: 25px;
+  margin-top: 1.5rem;
 }
 
 .post h1, .post h2, .post h3 {
@@ -690,8 +726,8 @@ section p {
 }
 
 .post p {
-  padding-bottom: 7.5px;
-  padding-top: 7.5px;
+  padding-bottom: 0.5rem;
+  padding-top: 0.5rem;
   font-size: 1.05rem;
 }
 
@@ -728,12 +764,11 @@ section p {
 }
 
 .post_content ol, .post_content ul {
-  list-style-type: initial;
-  padding: 0.5rem 1rem;
+  padding: 0.5rem 0 0.5rem 1.2rem;
 }
 
 .post_content li {
-  padding: 0.5rem 0;
+  padding: 0.33rem 0;
 }
 
 .post_header {
@@ -744,7 +779,7 @@ section p {
   color: #fff;
   height: 48vh;
   min-height: 360px;
-  background-color: #24292e;
+  background-color: #131313;
   margin-top: 60px;
   padding: 30px;
   display: flex;
@@ -774,27 +809,36 @@ section p {
 }
 
 .post_item {
-  box-shadow: 0 10px 25px -2px rgba(158, 174, 221, 0.2);
-  -webkit-filter: drop-shadow(-25px 15px 15px rgba(52, 90, 64, 0.17));
-  filter: drop-shadow(-25px 15px 15px rgba(52, 90, 64, 0.17));
-  background: #fff;
-  margin: 20px 0;
+  box-shadow: 0 0 3rem rgba(0, 0, 0, 0.17);
+  margin: 1.25rem 0;
   border-radius: 10px;
   overflow: hidden;
 }
 
+.post_item:hover {
+  box-shadow: 0 0 5rem rgba(0, 0, 0, 0.255);
+}
+
 .post_link {
   padding: 2.5px 0;
-  color: #000;
   font-size: 1.25em;
   margin: 2.5px 0;
   text-align: left;
 }
 
 .post_meta {
-  text-transform: uppercase;
+  overflow: hidden;
+  opacity: 0.8;
   font-size: 0.84rem;
   font-weight: 500;
+  display: inline-grid;
+  grid-template-columns: auto 1fr;
+  background-color: #fff;
+  padding: 0;
+  align-items: center;
+  border-radius: 0.3rem;
+  color: #131313;
+  text-transform: capitalize;
 }
 
 .post_meta a:hover {
@@ -803,15 +847,40 @@ section p {
   opacity: 0.9;
 }
 
+.post_extra {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .post_tag {
-  font-size: 0.84rem;
-  font-weight: 300;
-  color: #04a763;
+  font-size: 0.75rem !important;
+  font-weight: 500;
+  background: #04a763;
+  color: #fff;
+  padding: 0.25rem 0.67rem !important;
   text-transform: uppercase;
+  display: inline-flex;
+  border-radius: 5px;
 }
 
 .post_title {
   margin: 5px 0;
+}
+
+.post_author {
+  padding: 0.2rem 0.75rem;
+}
+
+.post_author a {
+  color: #04a763;
+  text-decoration: underline;
+}
+
+.post_time {
+  background: #04a763;
+  display: inline-grid;
+  padding: 0.2rem 0.75rem;
+  color: #fff;
 }
 
 .pager {
@@ -860,10 +929,23 @@ section p {
   opacity: 0.5;
 }
 
+.excerpt {
+  padding: 0 10px 1.5rem 10px;
+  position: relative;
+  z-index: 1;
+}
+
+.excerpt_meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  transform: translateY(-2.5rem);
+  position: relative;
+  z-index: 5;
+}
+
 .share {
-  box-shadow: 0 10px 25px -2px rgba(158, 174, 221, 0.2);
-  -webkit-filter: drop-shadow(-25px 15px 15px rgba(52, 90, 64, 0.17));
-  filter: drop-shadow(-25px 15px 15px rgba(52, 90, 64, 0.17));
+  box-shadow: 0 0 3rem rgba(0, 0, 0, 0.17);
   background: #fff;
   border-radius: 5px;
   align-items: center;
@@ -873,6 +955,10 @@ section p {
   height: 0;
   opacity: 0;
   overflow: hidden;
+}
+
+.share:hover {
+  box-shadow: 0 0 5rem rgba(0, 0, 0, 0.255);
 }
 
 .share a {
@@ -936,7 +1022,7 @@ section p {
   padding: 0;
   color: #fff;
   margin: 0;
-  background: #24292e;
+  background: #131313;
   width: 100%;
   font-size: 1.05rem;
   min-height: 75px;
@@ -953,16 +1039,10 @@ section p {
   opacity: 1;
 }
 
-.footer p {
-  padding: 0 10px;
-}
-
 .footer_inner {
-  width: 90%;
-  max-width: 1024px;
-  margin: 25px auto;
   display: flex;
-  justify-content: space-around;
+  justify-content: space-between;
+  padding: 1.5rem;
 }
 
 @media screen and (max-width: 567px) {
@@ -974,40 +1054,47 @@ section p {
 .form {
   display: flex;
   flex-direction: column;
-  max-width: 480px;
+  width: 100%;
+  background: transparent;
 }
 
 .form-comments {
   height: 0;
-  overflow: hidden;
-  padding: 0;
-  margin: 1rem 0;
-  transition: height 0.3s ease-in;
+  opacity: 0;
+  margin: 0 0 1rem;
+  transform: translateY(250px);
+  transition: opacity 0.3s ease-in , transform 0.3s ease-in;
+  border-radius: 0.67rem;
 }
 
 .form-open {
   height: initial;
+  transform: translateY(0);
+  opacity: 1;
 }
 
 .form_input {
   margin: 10px 0;
   font-size: 1rem !important;
   padding: 10px 15px !important;
-  border: 1px solid #04a763;
   -webkit-appearance: none;
   border-radius: 25px;
   outline: none;
   transition: all 0.3s ease-out;
+  width: 100%;
+  max-width: 480px;
+  box-shadow: 0 5px 15px 0 rgba(158, 174, 221, 0.2);
+  border: 1px solid #eee;
 }
 
 .form_input:focus, .form_input:hover {
-  box-shadow: 0 5px 15px 0 rgba(158, 174, 221, 0.2);
-  border: 1px solid #cccccc;
+  border: 1px solid #04a763;
 }
 
 .form_input-message {
   resize: none;
   border-radius: 15px;
+  min-height: 2.5rem !important;
 }
 
 .form_input-submit {
@@ -1030,90 +1117,24 @@ section p {
 }
 
 .form_toggle {
-  box-shadow: 0 10px 25px -2px rgba(158, 174, 221, 0.02);
-  -webkit-filter: drop-shadow(-25px 15px 15px rgba(52, 90, 64, 0.17));
-  filter: drop-shadow(-25px 15px 15px rgba(52, 90, 64, 0.17));
+  box-shadow: 0 0 3rem rgba(0, 0, 0, 0.02);
   background-color: #04a763;
-  margin-top: 1.5rem;
+  margin: 1rem 0;
   color: #fff;
   display: inline-block;
-  width: 150px;
-  padding: 10px;
+  width: 8rem;
+  padding: 0.33rem 1.5rem;
   text-align: center;
   cursor: pointer;
+  text-transform: capitalize;
 }
 
-.comment {
-  display: grid;
-  grid-template-columns: 1fr;
-  background: #f1f3f1;
-  margin: 0 0 1.5rem;
-  padding: 1rem 1.5rem;
-  border-radius: 0.5rem;
-  -webkit-filter: drop-shadow(-15px 9px 9px rgba(52, 90, 64, 0.17));
-  filter: drop-shadow(-15px 9px 9px rgba(52, 90, 64, 0.17));
+.form_toggle:hover {
+  box-shadow: 0 0 5rem rgba(0, 0, 0, 0.03);
 }
 
-@media screen and (min-width: 557px) {
-  .comment {
-    grid-template-columns: 1fr 6fr;
-  }
-}
-
-.comment p {
-  padding: 0 10px;
-}
-
-.comment_user {
-  border-radius: 50%;
-  margin: 0 1rem;
-}
-
-.comment_user {
-  width: 60px;
-}
-
-.comment_body {
-  flex: 1;
-  padding: 25px 0 0 15px;
-}
-
-.comment_s {
-  background: #fff;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  margin: 15px 0 0;
-  padding: 0;
-}
-
-.comment_s h3 {
-  margin: 10px 0;
-}
-
-.comment_icon img {
-  display: inline-block;
-  width: 18px;
-  height: 18px;
-  line-height: 2.5rem;
-  margin: 15px;
-  cursor: pointer;
-}
-
-.comment_meta {
-  width: 100%;
-  display: flex;
-  text-transform: uppercase;
-  font-weight: 500;
-  color: #000;
-  font-size: 0.84rem;
-  align-items: center;
-  flex-direction: row;
-  margin-bottom: .5rem;
-}
-
-.emoji {
-  width: auto;
+.comments {
+  position: relative;
 }
 
 .modal {
@@ -1139,7 +1160,7 @@ section p {
 
 .modal_inner {
   width: 100%;
-  background-color: #24292e;
+  background-color: #131313;
   max-width: 540px;
   padding: 25px;
   box-shadow: 0 25px 40px -10px rgba(158, 174, 221, 0.2);
@@ -1173,10 +1194,6 @@ section p {
   color: #fff;
 }
 
-.form {
-  position: relative;
-}
-
 .form-loading:before {
   content: '';
 }
@@ -1201,6 +1218,23 @@ section p {
   top: 50%;
   left: 50%;
   z-index: 11;
+}
+
+.highlight {
+  margin: 1.25rem 0;
+}
+
+.highlight .highlight {
+  margin: 0;
+}
+
+.highlight pre {
+  padding: 1rem;
+  margin: 1.5rem 0;
+  background: var(--bubble) !important;
+  box-shadow: 0 0 2.5rem rgba(0, 0, 0, 0.12);
+  border-radius: 4px;
+  overflow-x: auto;
 }
 
 /*# sourceMappingURL=main.css.map */

--- a/exampleSite/resources/_gen/assets/scss/main.scss_cabce47595c8b45ffa81339308153107.json
+++ b/exampleSite/resources/_gen/assets/scss/main.scss_cabce47595c8b45ffa81339308153107.json
@@ -1,0 +1,1 @@
+{"Target":"main.8b67407db10e958fe65954e6c87fa7cd2654266c28b345f48c3929e2396179c93c1d5819620f7e5872a0b7c3cec60fc1a26cea15e1dca974354ad67e3a6cd6f6.css","MediaType":"text/css","Data":{"Integrity":"sha512-i2dAfbEOlY/mWVTmyH+nzSZUJmwos0X0jDkp4jlheck8HVgZYg9+WHKgt8POxg/BomzqFeHcqXQ1StZ+OmzW9g=="}}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-<section class = 'post_header' style = 'background-image:url({{ $.Site.BaseURL }}images/{{ .Params.image }});'>
+<section class = 'post_header' style = 'background-image:url({{ path.Join "images" .Params.image | relLangURL }});'>
   <h1 class='post_title' itemprop='name headline'>{{ .Title }}</h1>
 </section>
 <div class = 'post'>
@@ -10,7 +10,9 @@
     </div>
     {{ partial "author.html" . }}
   </article>
-  {{ partial "comments.html" . }}
+  {{ if .Site.Params.Staticman }}
+    {{ partial "comments.html" . }}
+  {{ end }}
   <aside>
     <h3>Recent Posts</h3>
     <ul class='flex post_aside'>
@@ -23,6 +25,6 @@
     </ul>
   </aside>
 </div>
-<script src = '{{ $.Site.BaseURL }}js/autosize.min.js'></script>
-<script src = '{{ $.Site.BaseURL }}js/timeago.js'></script>
+<script src = '{{ "js/autosize.min.js" | relURL }}'></script>
+<script src = '{{ "js/timeago.js" | relURL }}'></script>
 {{ end }}

--- a/layouts/partials/audio.html
+++ b/layouts/partials/audio.html
@@ -1,5 +1,5 @@
 <div class = 'waves'>
   <canvas id = 'waves' class = 'waves_inner'></canvas>
 </div>
-<script src =  '{{ $.Site.BaseURL }}js/sine-waves.min.js'></script>
-<script src = '{{ $.Site.BaseURL }}js/audio.js'></script>
+<script src =  '{{ "js/sine-waves.min.js" | relURL }}'></script>
+<script src = '{{ "js/audio.js" | relURL }}'></script>

--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -4,11 +4,11 @@
 {{ if eq .name $author }}
   <div class = 'author'>
     <a href = '{{ .url }}' target = "{{ $author }}'s profile">
-      <img class = 'author_pic' src = '{{ $.Site.BaseURL }}images/{{ $author }}.jpg' alt = ''>
+      <img class = 'author_pic' src = '{{ printf "images/%s.jpg" $author }}' alt = ''>
     </a>
     <div class = 'author_meta'>
       <div class = 'pale author_heading'>WRITTEN BY</div>
-      <a class = 'author_name' href = '{{ .url }}' title = "{{ $author }}'s Profile">{{ .name }}</a>  
+      <a class = 'author_name' href = '{{ .url }}' title = "{{ $author }}'s Profile">{{ .name }}</a>
     </div>
     <p class = 'pale author_bio solo'>{{ .bio }}</p>
   </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,4 +4,4 @@
     <p>Designed by <a href = '{{ .Site.Data.designer.url }}' target = '_blank' title = 'Linkedin Profile' rel = 'nonopener'> {{ .Site.Data.designer.name }}</a></p>
   </div>
 </footer>
-<script src = '{{ $.Site.BaseURL }}js/index.js'></script>
+<script src = '{{ "js/index.js" | relURL }}'></script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -13,15 +13,15 @@
   <meta property = 'og:url' content = '{{ .Permalink }}' />
   {{ partial "opengraph.html" . }}
   {{ partial "analytics.html" . }}
-  <link rel="apple-touch-icon" sizes="180x180" href="{{ $.Site.BaseURL }}images/icons/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="{{ $.Site.BaseURL }}images/icons/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="{{ $.Site.BaseURL }}images/icons/favicon-16x16.png">
-  <link rel="manifest" href="{{ $.Site.BaseURL }}images/icons/site.webmanifest">
-  <link rel="mask-icon" href="{{ $.Site.BaseURL }}images/icons/safari-pinned-tab.svg" color="#5bbad5">
-  <meta name="msapplication-TileColor" content="#da532c">
-  <meta name="theme-color" content="#ffffff">
-  <link rel='canonical' href="{{ .Permalink }}">
+  <link rel='apple-touch-icon' sizes='180x180' href='{{ "images/icons/apple-touch-icon.png" | relURL }}'>
+  <link rel='icon' type='image/png' sizes='32x32' href='{{ "images/icons/favicon-32x32.png" | relURL }}'>
+  <link rel='icon' type='image/png' sizes='16x16' href='{{ "images/icons/favicon-16x16.png" | relURL }}'>
+  <link rel='manifest' href='{{ "images/icons/site.webmanifest" | relURL }}'>
+  <link rel='mask-icon' href='{{ "images/icons/safari-pinned-tab.svg" | relURL }}' color='#5bbad5'>
+  <meta name='msapplication-TileColor' content='#da532c'>
+  <meta name='theme-color' content='#ffffff'>
+  <link rel='canonical' href='{{ .Permalink }}'>
   {{- $options := (dict "targetPath" "main.css" "outputStyle" "expanded" "enableSourceMap" "true") -}}
-  {{- $styles := resources.Get "/main.scss" | resources.ToCSS $options | resources.Fingerprint "sha512" }}
+  {{- $styles := resources.Get "main.scss" | resources.ExecuteAsTemplate "main.scss" . | resources.ToCSS $options | resources.Fingerprint "sha512" }}
   <link rel = 'stylesheet' href = '{{ $styles.Permalink }}' integrity = '{{ $styles.Data.Integrity }}'>
 </head>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,6 +1,6 @@
 <header class = 'nav' >
   <nav class = 'nav-menu'>
-    <a href='{{ .Site.BaseURL }}' class = 'nav-brand nav_item'>{{ .Site.Title }}</a>
+    <a href='{{ "" | relLangURL }}' class = 'nav-brand nav_item'>{{ .Site.Title }}</a>
     <div class = 'nav_bar-wrap'>
       <div class = 'nav_bar'></div>
     </div>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,7 +1,7 @@
 <div class = 'nav-drop'>
   <div class = 'nav-body'>
     {{ range .Site.Data.menu }}
-      <a href = '{{ $.Site.BaseURL }}{{ .url }}' class = 'nav_item'>{{ .item }}</a>
+      <a href = '{{ relURL .url }}' class = 'nav_item'>{{ .item }}</a>
     {{ end }}
     <div class = 'nav-close'></div>
   </div>

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -23,13 +23,13 @@
       },
       "image":{
         "@type":"ImageObject",
-          "url":"{{ printf "images/%s" .Params.image | relURL }}"
+        "url":'{{ path.Join "images" .Params.image | relURL }}'
       },
       "publisher": {
         "@type": "Organization",
         "logo": {
           "@type":"ImageObject",
-          "url":"{{ printf "images/%s" .Site.Params.logo | relURL }}"
+          "url":'{{ path.Join "images" .Site.Params.logo | relURL }}'
         },
         "name": "{{ .Site.Title }}"
       }

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -1,4 +1,8 @@
-<meta property = 'og:image' content = '{{ .Site.BaseURL }}images/{{ with .Params.image }}{{ . }}{{ else }}{{ .Site.Params.image }}{{ end }}'/>
+{{ with .Params.image }}
+<meta property = 'og:image' content = '{{ path.Join  "images" . | relURL }}'/>
+{{ else }}
+<meta property = 'og:image' content = '{{ path.Join "images" .Site.Params.image | relURL }}'/>
+{{ end }}
 {{ if eq .Section "blog" -}}
   {{ $date := (time .Date)  }}
   <meta property = 'article:published_time' content = '{{ $date }}' />
@@ -17,15 +21,15 @@
         "@type": "Person",
         "name": "{{ .Params.author }}"
       },
-      "image":{  
+      "image":{
         "@type":"ImageObject",
-          "url":"{{ .Site.BaseURL }}images/{{ .Params.image }}"
+          "url":"{{ printf "images/%s" .Params.image | relURL }}"
       },
       "publisher": {
         "@type": "Organization",
         "logo": {
           "@type":"ImageObject",
-          "url":"{{ .Site.BaseURL }}images/{{ .Site.Params.logo }}"
+          "url":"{{ printf "images/%s" .Site.Params.logo | relURL }}"
         },
         "name": "{{ .Site.Title }}"
       }
@@ -35,5 +39,5 @@
   <meta name = 'twitter:creator' content = '{{ .Site.Params.twitter }}'>
   <meta name = 'twitter:title' content = '{{ .Title }}' />
   <meta property = 'twitter:description'  content = '{{ .Summary | truncate 250 }}'/>
-  <meta name = 'twitter:image' content = '{{ .Site.BaseURL }}images/{{ .Params.image }}' />
+  <meta name = 'twitter:image' content = '{{ path.Join "images" .Params.image | relURL }}' />
 {{ end }}

--- a/layouts/partials/pager.html
+++ b/layouts/partials/pager.html
@@ -1,12 +1,12 @@
 {{- $paginator := .Paginator }}
 {{- if gt $paginator.TotalPages 1 }}
-  <div class = 'pager'>   
+  <div class = 'pager'>
     <!-- {{ if $paginator.HasPrev }}
       <a href = '{{ $paginator.Prev.URL }}'  class = ' pager_item pager_prev'></a>
     {{ else }}
       <span class = ' pager_item pager_active pager_prev'></span>
     {{- end }} -->
-    
+
     {{ range $paginator.Pagers -}}
       <a href="{{ .URL }}" class = 'pager_item{{ if eq . $paginator }} pager_active{{ end }}'>{{ .PageNumber }}</a>
     {{ end }}

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -9,7 +9,7 @@ function elem(selector, parent = document){
 
 function elems(selector) {
   let elems = document.querySelectorAll(selector);
-  return elems.length ? elems : false; 
+  return elems.length ? elems : false;
 }
 
 function pushClass(el, targetClass) {
@@ -62,19 +62,19 @@ function isChild(node, parentClass) {
   let pop = 'nav-pop';
   let navDrop = elem(`.${drop}`);
   let hidden = 'hidden';
-  
+
   function toggleMenu(){
     modifyClass(navDrop, pop);
     modifyClass(navBar, hidden);
     let menuOpen = containsClass(nav, open);
     let menuPulled = containsClass(nav, exit);
-    
+
     let status = menuOpen || menuPulled ? true : false;
-    
+
     status ? modifyClass(nav, exit) : modifyClass(nav, open);
     status ? modifyClass(nav, open) : modifyClass(nav, exit);
   }
-  
+
   // $('.nav-bar, .nav-close').on('click', () => toggleMenu());
   navBar.addEventListener('click', function() {
     toggleMenu();
@@ -82,11 +82,11 @@ function isChild(node, parentClass) {
   elem('.nav-close').addEventListener('click', function() {
     toggleMenu();
   });
-  
+
   elem('.nav-drop').addEventListener('click', function(e) {
     e.target === this ? toggleMenu() : false;
   });
-  
+
 })();
 
 (function share(){
@@ -94,12 +94,12 @@ function isChild(node, parentClass) {
   let open = 'share-open';
   let close = 'share-close';
   let button = elem('.share-trigger');
-  
+
   function showShare() {
     pushClass(share, open);
     deleteClass(share, close);
-  } 
-  
+  }
+
   function hideShare() {
     pushClass(share, open);
     deleteClass(share, close);
@@ -113,7 +113,7 @@ function isChild(node, parentClass) {
 })();
 
 (function comments(){
-  
+
   let comments = elem('.js-comments');
   let form = elem('.form');
   let body = elem('body');
@@ -122,43 +122,43 @@ function isChild(node, parentClass) {
   let open = 'form-open';
   let show = 'modal_show'
   let toggled = 'toggled';
-  
+
   let successOutput = [
-    'Review submitted', 
+    'Review submitted',
     'Thanks for your review! It will show on the site once it has been approved.'
   ];
-  
+
   let errorOutput = [
-    'Error', 
+    'Error',
     'Sorry, there was an error with the submission!'
   ];
-  
+
   function handleForm(form) {
     form.addEventListener('submit', function (event) {
       pushClass(form, loading);
-      
+
       function resetForm() {
         deleteClass(form, loading);
         // $("form").trigger("reset");
       }
-      
+
       function formActions(message) {
         showModal(...message) // array destructuring
         resetForm();
       }
-      
+
       event.preventDefault();
-      
+
       function formToJSON(obj) {
         let rawData = Array.from(obj.elements);
         let data = {};
         rawData.forEach(function(element){
           data[element.name] = element.value;
         });
-        
+
         return JSON.stringify(data);
       }
-      
+
       let data = formToJSON(form);
       let url = form.getAttribute('action').trim();
       fetch(url, {
@@ -179,7 +179,7 @@ function isChild(node, parentClass) {
       });
     });
   }
-  
+
   form ? handleForm(form) : false;
   function closeModal() {
     elem('.modal_close').addEventListener('click', function () {
@@ -189,17 +189,17 @@ function isChild(node, parentClass) {
       deleteClass(button, toggled);
     });
   }
-  
+
   containsClass(body, show) ? closeModal() : false;
-  
+
   function showModal(title, message) {
     elem('.modal_title').textContent = title;
     elem('.modal_text').innerHTML = message;
-    
+
     pushClass(body, show);
   }
-  
-  
+
+
   (function toggleForm() {
     if(button) {
       button.addEventListener('click', function() {
@@ -209,7 +209,7 @@ function isChild(node, parentClass) {
       });
     }
   })();
-  
+
 })();
 
 function elemAttribute(elem, attr, value = null) {
@@ -227,7 +227,7 @@ function elemAttribute(elem, attr, value = null) {
     Array.from(links).forEach(function(link){
       let target, rel, blank, noopener, attr1, attr2, url, isExternal;
       url = elemAttribute(link, 'href');
-      isExternal = (url && typeof url == 'string' &&url.startsWith('http')) && !containsClass(link, 'nav_item') && !isChild(link, '.post_item') ? true : false;
+      isExternal = (url && typeof url == 'string' && url.startsWith('http')) && !containsClass(link, 'nav_item') && !isChild(link, '.post_item') && !isChild(link, '.pager') ? true : false;
       if(isExternal) {
         target = 'target';
         rel = 'rel';
@@ -235,7 +235,7 @@ function elemAttribute(elem, attr, value = null) {
         noopener = 'noopener';
         attr1 = elemAttribute(link, target);
         attr2 = elemAttribute(link, noopener);
-        
+
         attr1 ? false : elemAttribute(link, target, blank);
         attr2 ? false : elemAttribute(link, noopener, noopener);
       }
@@ -270,19 +270,19 @@ headingNodes.forEach(function(node){
 
 const copyToClipboard = str => {
   // Create a <textarea> element
-  const el = createEl('textarea');  
+  const el = createEl('textarea');
   // Set its value to the string that you want copied
-  el.value = str;                           
+  el.value = str;
   // Make it readonly to be tamper-proof
-  el.setAttribute('readonly', '');          
+  el.setAttribute('readonly', '');
   // Move outside the screen to make it invisible
-  el.style.position = 'absolute';                 
-  el.style.left = '-9999px';                
+  el.style.position = 'absolute';
+  el.style.left = '-9999px';
   // Append the <textarea> element to the HTML document
-  document.body.appendChild(el);            
+  document.body.appendChild(el);
   // Check if there is any content selected previously
-  const selected =            
-  document.getSelection().rangeCount > 0    
+  const selected =
+  document.getSelection().rangeCount > 0
   ? document.getSelection().getRangeAt(0)   // Store selection if found
   : false;                                  // Mark as false to know no selection existed before
   el.select();                              // Select the <textarea> content
@@ -303,7 +303,7 @@ const copyToClipboard = str => {
       let target = event.target;
       if (target.classList.contains(deeplink) || target.parentNode.classList.contains(deeplink)) {
         event.preventDefault();
-        let newLink = target.href != undefined ? target.href : target.parentNode.href; 
+        let newLink = target.href != undefined ? target.href : target.parentNode.href;
         copyToClipboard(newLink);
       }
     });


### PR DESCRIPTION
TODO:

- [x] resolve #17 
- [x] resolve #21 
- [ ] i18n framework
- [ ] Staticman nested comments (see project for details)

Supposed the uncertainty of @onweru's response time, I've chosen to bundle my resolution to the above problems together so as to minimise the possibility of merge conflicts during my future work on the later two tasks.  I haven't read the entire book *Pro Git*, so I dunno whether this is the best Git practice.  Feel free to cherry-pick any published commits inside this PR.  Don't hesitate to leave a feedback/question/commit if needed.

A i18n framework is simply putting every UI string like "Designed by" into a data file under `i18n`.  Some examples include [Beautifhul Hugo](https://github.com/halogenica/beautifulhugo) and [Introduction](https://github.com/victoriadrake/hugo-theme-introduction).  This forms a good (though not necessary) basis for the next feature.

Nested comments of one level depth keep the comments section organised.  Examples include:

1. [zcrc.me](https://zcrc.me/retromini/2019/05/17/opendingux-release-20190517.html)
2. [Network Hobo](https://networkhobo.com/2017/12/30/hugo-staticman-nested-replies-and-e-mail-notifications/)
3. [Mr Tortue](https://mrtortue.com/aquarium-naturel-sans-filtre-pas-cher/)
4. [My blog](https://vincenttam.gitlab.io/post/2018-09-16-staticman-powered-gitlab-pages/2/)

However, in the first three examples, there's no visually clear way to represent the following common situation.

1. main comment A
    1. O replies to A
    2. C also replies to A
    3. D replies to O
2. main comment B

To improve this, I'll port my previous work for

- Huginn: https://lstu.fr/hg (https://themes.gohugo.io/huginn/)
- Introduction: https://lstu.fr/ism19 (https://github.com/victoriadrake/hugo-theme-introduction/pull/119)

into here.

Regarding backward compatibility, this should be backward compatible since missing fields (`replyThread`, `replyID`, `replyName`) in static comment data files won't cause a runtime error displayed in the terminal.  The Go-HTML code inside an `{{ if .replyThread }}...{{ end }}` block is simply ignored.

P.S. Of course, site owners may manually modify these three `reply*` fields in their comment data file(s) to deliver an appropriate visual display according to the context, due to the site owner's total ownership of static comments—but that's out of the scope of this PR.

P.S. I'm using Atom, Sublime Text 3 and Vim for my editing, with no fixed choices.  The automatic removal of trailing spaces and the automatic addition of missing EOL are due to (one of the?) former two editors.  In each Git diff hunk, the three lines above and/or below each changed line are displayed.  This "change" might interfere with other PRs in case of Git merges with different branches, causing a merge conflict, so that manual inspection and resolution are needed.  Having good commit styles described in the commit message at https://github.com/onweru/hugo-swift-theme/commit/31d40fd361d754aca840eceaeec266e2bf6ec7b8 help saving our manpower.  Please consider running `git diff --ws-error-highlight=all` before actually staging your files in the future.