### PR TITLE
look for posts in post folder

### DIFF
--- a/layouts/partials/archive.html
+++ b/layouts/partials/archive.html
@@ -1,6 +1,8 @@
 {{ partial "intro.html" . }}
+{{ $paginator := .Paginate (where .Site.RegularPages "Section" "post").ByPublishDate.Reverse }}
+
 <ul class='posts wrap' id = 'posts'>
-  {{- range .Paginator.Pages }}
+  {{- range $paginator.Pages }}
     {{ partial "excerpt.html" . }}
   {{- end }}
 </ul>

--- a/layouts/partials/aside.html
+++ b/layouts/partials/aside.html
@@ -5,7 +5,7 @@
   <!-- filter out the current post -->
   <!-- return atmost 2 posts -->
   {{ $title := .Params.title }}
-  {{ range first 2 .Site.RegularPages }}
+  {{ range first 2 (where .Site.RegularPages "Section" "post").ByPublishDate.Reverse  }}
     {{ if not (eq .Title $title) }}
     {{ partial "excerpt.html" . }}
     {{ end }}


### PR DESCRIPTION
Hi, this change looks for blog posts in "post" folder under content in order not to display "about" page (and other pages if would be added) among other blog entries