### PR TITLE
Change path for public in GITIGNORE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-public
+exampleSite/public
 docs
 .DS_Store


### PR DESCRIPTION
It's a [common practice](https://github.com/search?q=%22cd+exampleSite%22&type=Code) to `cd exampleSite` before `hugo --themesDir ../..`, so the generated :file_folder: `public` would lie inside `exampleSite`.  See, for e.g. the [Introduction](https://github.com/victoriadrake/hugo-theme-introduction).