### PR TITLE
Added a locale string "More from"

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -64,3 +64,5 @@
   other = "Sorry, there was an error with the submission!"
 [replyToMsg]
   other = "Reply to this comment"
+[moreFrom]
+  other = "More from {{ . }}"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -64,3 +64,5 @@
   other = "Désolé, une erreur s'est produite lors de l'envoi du commentaire !"
 [replyToMsg]
   other = "Répondre à ce commentaire"
+[moreFrom]
+  other = "Plus de billets sur {{ . }}"

--- a/i18n/zh-CN.toml
+++ b/i18n/zh-CN.toml
@@ -64,3 +64,5 @@
   other = "抱歉，提交留言出错！"
 [replyToMsg]
   other = "回覆该讯息"
+[moreFrom]
+  other = "更多 {{ . }} 文章"

--- a/i18n/zh-TW.toml
+++ b/i18n/zh-TW.toml
@@ -64,3 +64,5 @@
   other = "抱歉，提交留言出錯！"
 [replyToMsg]
   other = "回覆該訊息"
+[moreFrom]
+  other = "更多 {{ . }} 文章"

--- a/layouts/partials/aside.html
+++ b/layouts/partials/aside.html
@@ -1,4 +1,4 @@
-<h3>More From {{ .Site.Title }}</h3>
+<h3>{{ i18n "moreFrom" .Site.Title }}</h3>
 <ul class='posts aside'>
   {{ $kin := (where .Site.RegularPages ".Params.tags" "intersect" .Params.tags) }}
   {{ $siblings := (where $kin ".Title" "!=" .Title) }}


### PR DESCRIPTION
In response to @onweru's comment in issue https://github.com/onweru/hugo-swift-theme/issues/24#issuecomment-520856972.

:warning: In the future, please **avoid adding English words directly into any visible components** of the theme.  Instead, put a i18n string like `{{ i18n "stringToBeTranslated" }}` in the template, and add the entry `stringToBeTranslated` to *each* i18n file.  It's OK to leave string untranslated in some languages.  We aren't necessarily language experts.  But please, follow the internationalization framework set up in #26.