### PR TITLE
Show Hugo version number in a meta tag

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,6 +1,7 @@
 <head>
   <title>{{ with .Title }}{{ humanize . }} | {{ end }}{{ .Site.Title }}</title>
   <meta charset='utf-8'>
+  {{ hugo.Generator }}
   {{- with .Site.Params.ga_verify }}
   <meta name="google-site-verification" content="{{ . }}" />
   {{- end }}


### PR DESCRIPTION
To allow debugging in case of bug report.  Learned from https://github.com/pacollins/hugo-future-imperfect-slim/blob/d80bfe573cb7f423be4fe861a1dd108aac3eef0e/layouts/partials/head.html#L3.