### PR TITLE
Fixed typo in JSON object

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -161,7 +161,7 @@ function isChild(node, parentClass) {
           fields: {
             name: elem('input[name="fields[name]"]', form).value,
             email: elem('input[name="fields[email]"]', form).value,
-            comment: elem('input[name="fields[name]"]', form).value,
+            comment: elem('input[name="fields[comment]"]', form).value,
             replyID: elem('input[name="fields[replyID]"]', form).value,
             replyName: elem('input[name="fields[replyName]"]', form).value,
             replyThread: elem('input[name="fields[replyThread]"]', form).value


### PR DESCRIPTION
In the JSON request
https://github.com/onweru/hugo-swift-theme/blob/0b5546528e9aa8e8b3c7f67f66b2e89b6d90b792/assets/js/index.js#L160-L178
I've made a careless mistake for the key `comment` after two days of adpating the Go-HTML template, jQuery code into pure JavaScript and searching for a way to post JSON strings into a Staticman API from JS.

It should be
https://github.com/onweru/hugo-swift-theme/blob/6df4d180ed90c286379a537a9044607b3c032aac/assets/js/index.js#L164