### PR TITLE
Shortened string for comment reply button

### DIFF
--- a/assets/scss/_components.scss
+++ b/assets/scss/_components.scss
@@ -183,7 +183,4 @@ section p{
     flex-flow: column;
     justify-content: center;
   }
-  &_reply-btn {
-    width: max-content;
-  }
 }

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -62,7 +62,7 @@
   other = "Error"
 [errMsg]
   other = "Sorry, there was an error with the submission!"
-[replyToMsg]
-  other = "Reply to this comment"
+[reply]
+  other = "Reply"
 [moreFrom]
   other = "More from"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -62,7 +62,7 @@
   other = "Erreur"
 [errMsg]
   other = "Désolé, une erreur s'est produite lors de l'envoi du commentaire !"
-[replyToMsg]
-  other = "Répondre à ce commentaire"
+[reply]
+  other = "Répondre"
 [moreFrom]
   other = "Plus de billets sur"

--- a/i18n/zh-CN.toml
+++ b/i18n/zh-CN.toml
@@ -62,7 +62,7 @@
   other = "错误"
 [errMsg]
   other = "抱歉，提交留言出错！"
-[replyToMsg]
-  other = "回覆该讯息"
+[reply]
+  other = "回覆"
 [moreFrom]
   other = "更多 {{ . }} 文章"

--- a/i18n/zh-TW.toml
+++ b/i18n/zh-TW.toml
@@ -62,7 +62,7 @@
   other = "錯誤"
 [errMsg]
   other = "抱歉，提交留言出錯！"
-[replyToMsg]
-  other = "回覆該訊息"
+[reply]
+  other = "回覆"
 [moreFrom]
   other = "更多 {{ . }} 文章"

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -17,7 +17,7 @@
             </div>
             <p class = 'solo comment_bio pale'>{{ .comment | markdownify }}</p>
             <div class = 'comment_threadID hidden'>{{ ._id }}</div>
-            <a class='btn comment_reply-btn' href='#comments-form'>{{ i18n "replyToMsg" }}</a>
+            <a class='btn comment_reply-btn' href='#comments-form'>{{ i18n "reply" }}</a>
           </article>
 
           {{ range $comments }}
@@ -30,7 +30,7 @@
                 </div>
                 <p class = 'solo comment_bio pale'>{{ .comment | markdownify }}</p>
                 <div class = 'comment_threadID hidden'>{{ .replyThread }}</div>
-                <a class='btn comment_reply-btn' href='#comments-form'>{{ i18n "replyToMsg" }}</a>
+                <a class='btn comment_reply-btn' href='#comments-form'>{{ i18n "reply" }}</a>
               </article>
             {{ end }}
           {{ end }}


### PR DESCRIPTION
Fixed #43.

1. Shortened the string.
2. Shortened the key name in i18n.
3. Removed unnecessary SCSS rule for design consistency.