### PR TITLE
Updated Hugo syntax for listing pages due to Hugo 0.57.0

### DIFF
--- a/layouts/partials/archive.html
+++ b/layouts/partials/archive.html
@@ -1,6 +1,10 @@
 {{ partial "intro.html" . }}
 <ul class='posts wrap' id = 'posts'>
-  {{ $paginator := .Paginate (where .Data.Pages "Section" "!=" "").ByPublishDate.Reverse }}
+  {{- $pages := .Pages -}}
+  {{  if .IsHome }}
+  {{ $pages = (where site.RegularPages "Type" "in" site.Params.mainSections) }}
+  {{  end }}
+  {{ $paginator := .Paginate $pages.ByPublishDate.Reverse }}
   {{- range $paginator.Pages }}
     {{ partial "excerpt.html" . }}
   {{- end }}


### PR DESCRIPTION
In gohugoio/hugoThemes#<span>682</span>, @<span>onedrawingperday</span> has recommended  the use of [`mainSections`](https://gohugo.io/functions/where/#mainsections).

```go
{{ $pages := .Pages }}
{{ if .IsHome }}
{{ $pages = .Site.RegularPages }}
{{ end }}
{{ $paginator := .Paginate $pages }}
```

for listing pages.  This gives unified page list in the homepage and in the section pages.  Even though our project isn't listed in the aforementioned issue, it's good to update our syntax so as to fit into the recently released Hugo v0.57.0.

:information_source: I didn't create link to the official Hugo repo to avoid creating reference there.

* * *

Edited: If you don't like the selection logic in
https://github.com/onweru/hugo-swift-theme/blob/56d6e38357984fb992d6e15d984df0f336b7466f/layouts/partials/archive.html#L5
feel free to change `"Type"` back to `"Section"` like

```go
{{ $paginator := .Paginate ( where .Site.RegularPages "Section" "ne" "profiles" ) }}
```
Source: https://github.com/mazgi/hugo-theme-techlog-simple/pull/5/files#diff-3db8db7226d7f28bb43b59ce30ad6157

:warning: I don't like the "hard-coding" approach in the above code block though.  See Hugo's docs about [`mainSection`](https://gohugo.io/functions/where/#mainsections).

> To list the most relevant pages on the front page or similar, **you should use the `site.Params.mainSections` list** instead of comparing section names to hard-coded values like `"posts"` or `"post"`.

Test results of this PR:

1. Tags pages

    ![Screenshot from 2019-08-17 17-01-18](https://user-images.githubusercontent.com/5748535/63214954-a81b0200-c11f-11e9-8723-652c70d76f0d.png)

    ![Screenshot from 2019-08-17 17-01-14](https://user-images.githubusercontent.com/5748535/63214955-a81b0200-c11f-11e9-83a4-d2206758aa26.png)

2. Homepage

    ![Screenshot from 2019-08-17 17-01-07](https://user-images.githubusercontent.com/5748535/63214960-c123b300-c11f-11e9-9477-4b61a98af8c9.png)
