### PR TITLE
Updated README & default to GitLab instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Swift Theme
 
-This theme is designed for blogging purposes. Feel free to extend it for other use cases though.
+This theme is designed for blogging purposes. Feel free to extend it for other
+use cases though.
 
-At its core, it's minimalistic; it doesn't rely on monolithic libraries such e.g jquery, bootstrap. Instead, it uses *grid css*, *flexbox* & *vanilla js* to facilitate the `features` outlined below:
+At its core, it's minimalistic; it doesn't rely on monolithic libraries such e.g
+jquery, bootstrap. Instead, it uses *grid css*, *flexbox* & *vanilla js* to
+facilitate the `features` outlined below:
 
 ![Hugo Swift Theme](https://github.com/onweru/hugo-swift-theme/blob/master/images/screenshot.png)
 
@@ -14,7 +17,7 @@ At its core, it's minimalistic; it doesn't rely on monolithic libraries such e.g
 * Deeplinks
 * Dark Mode
 * Syntax Highlighting
-* [Staticman](https://staticman.net)
+* [Staticman](#staticman-comments)
   * [reCAPTCHA](https://developers.google.com/recaptcha/docs/display)
 
 ## Installation
@@ -43,67 +46,25 @@ You can configure the site using as follows:
 
 ## Staticman Comments
 
-By default, [Staticman](https://staticman.net) comments are disabled. If you would like to enable them,
-
-1. Invite Staticman to your repo to collaborate.
-
-    * GitHub: View the issue [eduardoboucas/staticman#243](https://github.com/eduardoboucas/staticman/issues/243) for procedures to set up Staticman v3.
-    * GitLab: Add the GitLab user associated with your Staticman API endpoint (e.g. **[@staticmanlab](https://gitlab.com/staticmanlab)**) as a "**developer**" for your project by going to **Settings → Members → Invite member**.
-    * Framagit: Since Framagit is a fork of GitLab, the overall setup is similar to that on GitLab.  (Note that the Framagit bot is named as **[@staticmanlab1](https://framagit.org/staticmanlab1)**.)
-
-2. Uncomment the `[Params.staticman]` section and input the parameters inside `config.toml` like so
-
-    ```toml
-    [Params.staticman]
-      endpoint = "https://api.staticman.net"
-      gitProvider = "github"
-      username = "your-username"
-      repository = "hugo-swift-theme"
-      branch = "master"
-    ```
-
-    In case of empty `endpoint`, it will fallback to the official production instance.
-
-    | instance | `endpoint` |
-    | --- | --- |
-    | official production | `https://api.staticman.net` |
-    | GitLab | `https://staticman3.herokuapp.com` |
-    | Framagit | `https://staticman-frama.herokuapp.com` |
-
-    Remark: You may adjust the `endpoint` to the one that your Staticman bot/GitHub App is associated with.
-
-    For `gitProvider`, you can choose either `github` or `gitlab`.  If you're using Framagit, choose `gitlab`.
-
-3. Proceed to setup `staticman.yml`.  Note that this YML file has to be **at the root of your Git repository**.  See the `exampleSite/` and the [Staticman docs](https://staticman.net/docs/) for detailed information of each parameter used in this YML file.
-
-    The parameter `moderation` is for comment moderation, and it defaults to `false`.  If it is switched to `true`, then Staticman will create a pull/merge request instead of directly committing against the `branch`.
-
-    If you are working on GitLab and you have set `moderation: false`, depending on your `branch`, you might need the following steps.
-
-      * protected branch (e.g. `master`):
-        Go to **Settings → Repository → Protected Branches** and permit the GitLab bot to push against that branch.
-      * unprotected branch (GitHub's default): no measures needed
-
-Optional: It is suggested to enable [reCAPTCHA](https://developers.google.com/recaptcha/docs/display) to avoid massive spam comments. You may refer to `_config.yml` for detailed instructions.
-
-Optional: You may want to configure a webhook to prevent old inactive branches (representing approved comments) from stacking up.  You can refer to [Staticman's documentation](https://staticman.net/docs/webhooks) for details.  Make sure to input the **Payload URL** according to your chosen `endpoint`.  For example, the default `endpoint` is `https://staticman3.herokuapp.com`, so the corresponding **Payload URL** should be `https://staticman3.herokuapp.com/v1/webhook`.
-
-:information_source: This [Binary Mist article](https://binarymist.io/blog/2018/02/24/hugo-with-staticman-commenting-and-subscriptions/) could also be quite helpful :)
-
-:information_source: By default, this theme uses the official production instance at v3 instead of v2 due to a requests' quota issue reported in issue [eduardoboucas/staticman#222](https://github.com/eduardoboucas/staticman/issues/222).
-
-:warning: Since Staticman is an evolving project, things might work differently than they do at the moment of this writing.
+By default, [Staticman](https://staticman.net) comments are disabled.
+To enable them, you may refer to the
+[Staticman config Wiki](https://github.com/onweru/hugo-swift-theme/wiki/staticman-config).
 
 ### Deeplinks
 
-For all content published using markdown, deeplinks will be added to the pages so that you can share with precision :smiley: Just   hover on a heading and the link button will pop. Click it to copy.
+For all content published using markdown, deeplinks will be added to the pages
+so that you can share with precision :smiley: Just   hover on a heading and the
+link button will pop. Click it to copy.
 
 ### Dark Mode
 
-Today most operating systems & browsers support dark mode. Like twitter, which automatically turns into dark mode when the user chooses darkmode, this theme does the same thing.
+Today most operating systems & browsers support dark mode. Like twitter, which
+automatically turns into dark mode when the user chooses darkmode, this theme
+does the same thing.
 
 ![Dark Mode](https://github.com/onweru/hugo-swift-theme/blob/master/images/darkmode.jpg)
 
 ## License
 
-The code is available under the [MIT license](https://github.com/onweru/hugo-swift-theme/blob/master/LICENSE.md).
+The code is available under the
+[MIT license](https://github.com/onweru/hugo-swift-theme/blob/master/LICENSE.md).

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -8,7 +8,7 @@
   const doc = document.documentElement;
   const staticman = Object.create(null);
   {{ with .Site.Params.staticman -}}
-  const endpoint = '{{ .endpoint | default "https://staticman-frama.herokuapp.com" }}';
+  const endpoint = '{{ .endpoint | default "https://staticman3.herokuapp.com" }}';
   const gitProvider = '{{ .gitprovider }}';
   const username = '{{ .username }}';
   const repository = '{{ .repository }}';


### PR DESCRIPTION
# Description

1. Formated README to a text width of 80 for smarter `git diff` output in terminals with normal buffer width (80).
2. Added anchor for quickly jumping to the section **Staticman Comments**.
3. Resolved #51 by replacing the Staticman setup procedures in the README by a link to the [Staticman config Wiki](https://github.com/onweru/hugo-swift-theme/wiki/staticman-config).
4. <del>BREAKING</del> change: changed default `endpoint` back to `staticman3.herokuapp.com` due to webhook problems described in https://github.com/eduardoboucas/staticman/pull/288#issuecomment-508275857.  (Both the Framagit and GitLab instances are associated to the same bot @staticmanlab, so there shouldn't be any authorisation error after this change.)